### PR TITLE
Issue 3 - Reduced page size to have .NET recognise it

### DIFF
--- a/src/Our.Umbraco.Impersonator/wwwroot/user.controller.js
+++ b/src/Our.Umbraco.Impersonator/wwwroot/user.controller.js
@@ -25,8 +25,8 @@
         // Get users
         usersResource
           .getPagedResults({
-            pageSize: Number.MAX_SAFE_INTEGER,
-            userStates: ["Active"],
+              pageSize: 2147483647,
+              userStates: ["Active"],
           })
           .then(
             function (data) {


### PR DESCRIPTION
From [issue 3](https://github.com/skttl/umbraco-impersonator/issues/3), this corrects the bug where the list of users would be capped at the default 10 items.

I can't imagine the DOM would thank you for spitting out 2147483647 records, so this could be reduced down to something a lot less (something like 2000, I'd suggest) but kept it as high as possible.

Here's an example with a list of 13 users.

Before fix:
![image](https://github.com/skttl/umbraco-impersonator/assets/5808078/97de7ba1-6cf7-4fc1-9ff2-5920f9d66282)

After fix:
![image](https://github.com/skttl/umbraco-impersonator/assets/5808078/b3fd329c-35d8-4e77-93ca-e35aedfb0694)
