### PR TITLE
Remove current user from list

### DIFF
--- a/src/Our.Umbraco.Impersonator/wwwroot/lang/da-DK.xml
+++ b/src/Our.Umbraco.Impersonator/wwwroot/lang/da-DK.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="da" intName="Danish" localName="dansk" lcid="6" culture="da-DK">
 	<creator>
 		<name>Søren Kottal</name>
@@ -15,6 +15,7 @@
 		<key alias="notSignedIn">Du skal være logget ind i Umbraco for at kunne imitere en anden bruger</key>
 		<key alias="userNotFound">Den valgte bruger kunne ikke findes</key>
 		<key alias="invalidUserId">Det valgte bruger ID er ikke gyldigt</key>
-		<key alias="notAdministrator">Du skal have administratorrettigheder for at kunne imitere en anden bruger</key>
+		<key alias="notAdministrator">Du skal have brugeradministratorrettigheder for at kunne imitere en anden bruger</key>
+		<kay alias="noUser">Der er ingen aktive brugere at imiterer.</kay>
 	</area>
 </language>

--- a/src/Our.Umbraco.Impersonator/wwwroot/lang/da-DK.xml
+++ b/src/Our.Umbraco.Impersonator/wwwroot/lang/da-DK.xml
@@ -16,6 +16,6 @@
 		<key alias="userNotFound">Den valgte bruger kunne ikke findes</key>
 		<key alias="invalidUserId">Det valgte bruger ID er ikke gyldigt</key>
 		<key alias="notAdministrator">Du skal have brugeradministratorrettigheder for at kunne imitere en anden bruger</key>
-		<kay alias="noUser">Der er ingen aktive brugere at imiterer.</kay>
+		<kay alias="noUser">Der er ingen aktive brugere at imitere.</kay>
 	</area>
 </language>

--- a/src/Our.Umbraco.Impersonator/wwwroot/lang/en-US.xml
+++ b/src/Our.Umbraco.Impersonator/wwwroot/lang/en-US.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="en_us" intName="English (US)" localName="English (US)" lcid="" culture="en-US">
 	<creator>
 		<name>Søren Kottal</name>
@@ -15,6 +15,7 @@
 		<key alias="notSignedIn">You need to be signed in to Umbraco, to be able to impersonate another user.</key>
 		<key alias="userNotFound">The selected user could not be found.</key>
 		<key alias="invalidUserId">The selected user id is invalid.</key>
-		<key alias="notAdministrator">You need administrator rights, to be able to impersonate another user.</key>
+		<key alias="notAdministrator">You need users administrator rights, to be able to impersonate another user.</key>
+		<key alias="noUser">There are no active users to impersonate.</key>
 	</area>
 </language>

--- a/src/Our.Umbraco.Impersonator/wwwroot/user.controller.js
+++ b/src/Our.Umbraco.Impersonator/wwwroot/user.controller.js
@@ -1,4 +1,4 @@
-﻿(function () {
+(function () {
   "use strict";
 
   function ImpersonatorUserController(
@@ -12,7 +12,6 @@
     var vm = this;
 
     vm.isImpersonating = false;
-    vm.isLoading = false;
     vm.users = [];
     vm.loadingUsers = true;
     vm.impersonateUserButtonState = "init";
@@ -25,18 +24,22 @@
         // Get users
         usersResource
           .getPagedResults({
-              pageSize: 2147483647,
-              userStates: ["Active"],
+            pageSize: 2147483647,
+            userStates: ["Active"],
           })
           .then(
             function (data) {
-              vm.users = data.items;
+              vm.users = data.items.filter(function (u) { return u.id != user.id }); // remove current user from impersonation list
               vm.loadingUsers = false;
             },
             function (error) {
               vm.loadingUsers = false;
             }
           );
+      }
+      else {
+        // No users to load, we're done
+        vm.loadingUsers = false;
       }
     });
 

--- a/src/Our.Umbraco.Impersonator/wwwroot/user.html
+++ b/src/Our.Umbraco.Impersonator/wwwroot/user.html
@@ -1,10 +1,9 @@
-﻿<div ng-controller="Impersonator.User.Controller as vm">
-  <umb-box ng-if="vm.isImpersonating && !vm.isLoading">
+<div ng-controller="Impersonator.User.Controller as vm">
+  <umb-box ng-if="vm.isImpersonating && !vm.loadingUsers">
     <umb-box-content>
       <div class="mb2">
         <localize key="impersonator_impersonatingDescription"
-          >You are impersonating the current user.</localize
-        >
+          >You are impersonating the current user.</localize>
       </div>
       <div class="text-right">
         <umb-button
@@ -13,14 +12,14 @@
           label-key="impersonator_endImpersonation"
           button-style="primary"
           state="vm.endImpersonationButtonState"
-        ></umb-button>
-      </div>
+          ></umb-button>
+        </div>
     </umb-box-content>
   </umb-box>
   <umb-box
-    ng-if="vm.canImpersonateUsers && !vm.isImpersonating && !vm.isLoading"
+    ng-if="vm.canImpersonateUsers && !vm.isImpersonating && !vm.loadingUsers"
   >
-    <umb-box-content>
+    <umb-box-content ng-if="vm.users.length > 0">
       <div class="flex">
         <select
           class="umb-dropdown flx-g1 mb0"
@@ -33,7 +32,24 @@
           label-key="impersonator_impersonate"
           button-style="primary"
           state="vm.impersonateUserButtonState"
+          disabled="!vm.userToImpersonate"
         ></umb-button>
+      </div>
+    </umb-box-content>
+    <umb-box-content ng-if="vm.users.length <= 0">
+      <div class="mb2">
+        <localize key="impersonator_noUser">
+          There are no active users to impersonate
+        </localize>
+      </div>
+    </umb-box-content>
+  </umb-box>
+  <umb-box ng-if="!vm.canImpersonateUsers && !vm.isImpersonating && !vm.loadingUsers">
+    <umb-box-content>
+      <div class="mb2">
+        <localize key="impersonator_notAdministrator">
+          You need users administrator rights, to be able to impersonate another user.
+        </localize>
       </div>
     </umb-box-content>
   </umb-box>


### PR DESCRIPTION
This resolves issue #6 and I took the liberty to do some fine-tuning as follow

- The current user does not appear in the list a,nymore

![image](https://github.com/skttl/umbraco-impersonator/assets/1769475/a8001509-2f96-48ca-bd40-39aecada5ca8)

- The "imperonate" button is disabled until you select a user (see image above)

- If the list is empty, we display a message "no user to impersonate"

![image](https://github.com/skttl/umbraco-impersonator/assets/1769475/aafaefe6-456e-4d01-bf9c-fe554c9d3329)

- When a non-admin user opens the layer, we display a message "you need admin rights".

![image](https://github.com/skttl/umbraco-impersonator/assets/1769475/9f992537-1cd3-4d1f-81b0-2117bd8c3672)

The two latter points are there because we actually always have the dashboard title "User Impersonation" displayed, which means that if the impersonation component itself would not display anything (like it is now), the user sees a title with nothing under it, and I thought this seemed kind of odd. 😉

Beware that updates to Danish translation file come from Google translate 😅